### PR TITLE
Adds `IClientBuilder` extension method for registering ISyncWorker

### DIFF
--- a/src/Orleans.SyncWork/ExtensionMethods/ClientBuilderExtensions.cs
+++ b/src/Orleans.SyncWork/ExtensionMethods/ClientBuilderExtensions.cs
@@ -1,0 +1,19 @@
+namespace Orleans.SyncWork.ExtensionMethods;
+
+/// <summary>
+/// Extension methods for <see cref="IClientBuilder"/>.
+/// </summary>
+public static class ClientBuilderExtensions
+{
+    /// <summary>
+    /// Configures assembly scanning against this assembly containing the <see cref="ISyncWorker{TRequest, TResult}"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IClientBuilder"/> instance.</param>
+    /// <returns>The <see cref="IClientBuilder"/> to allow additional fluent API chaining.</returns>
+    public static IClientBuilder ConfigureSyncWorkAbstraction(this IClientBuilder builder)
+    {
+        builder.ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(ISyncWorkAbstractionMarker).Assembly).WithReferences());
+
+        return builder;
+    }
+}

--- a/src/Orleans.SyncWork/Orleans.SyncWork.csproj
+++ b/src/Orleans.SyncWork/Orleans.SyncWork.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.Orleans.Core" Version="3.1.0" />
     <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.1.0" />
     <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Orleans.SyncWork.Tests/ExtensionMethods/ClientBuilderExtensionsTests.cs
+++ b/test/Orleans.SyncWork.Tests/ExtensionMethods/ClientBuilderExtensionsTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Orleans.SyncWork.Demo.Services.Grains;
+using Orleans.SyncWork.ExtensionMethods;
+using Orleans.SyncWork.Tests.TestGrains;
+using Orleans.TestingHost;
+using Xunit;
+
+namespace Orleans.SyncWork.Tests.ExtensionMethods;
+
+public class ClientBuilderExtensionsTests
+{
+    private class ClientBuilderNoConfigureSyncWorkAbstraction : IClientBuilderConfigurator
+    {
+        public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+        {
+            // Configuring the addition of application parts for *this* assembly only, so that the automatic assembly scanning,
+            // which would pick up Orleans.SyncWork grains does not fire.
+            clientBuilder.ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(TestGrain).Assembly));
+        }
+    }
+    
+    private class ClientBuilderConfigureSyncWorkAbstraction : IClientBuilderConfigurator
+    {
+        public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+        {
+            clientBuilder.ConfigureSyncWorkAbstraction();
+        }
+    }
+    
+    [Fact]
+    public async Task WhenNotCallingConfigureSyncWorkAbstraction_ShouldNotResolveSyncWorkGrain()
+    {
+        var builder = new TestClusterBuilder();
+        builder.AddClientBuilderConfigurator<ClientBuilderNoConfigureSyncWorkAbstraction>();
+        
+        var cluster = builder.Build();
+        await cluster.DeployAsync();
+
+        var action = new Action(() => cluster.Client.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid()));
+        
+        action.Should().Throw<InvalidOperationException>("The extension method to add parts was not invoked, and an exception will be thrown as no grain reference can be made.");
+    }
+    
+    [Fact]
+    public async Task WhenCallingConfigureSyncWorkAbstraction_ShouldResolveSyncWorkGrain()
+    {
+        var builder = new TestClusterBuilder();
+        builder.AddClientBuilderConfigurator<ClientBuilderConfigureSyncWorkAbstraction>();
+        
+        var cluster = builder.Build();
+        await cluster.DeployAsync();
+        var grain = cluster.Client.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+
+        grain.Should().NotBeNull("The extension method to add parts was invoked");
+    }
+}

--- a/test/Orleans.SyncWork.Tests/ExtensionMethods/SiloHostBuilderExtensionsTests.cs
+++ b/test/Orleans.SyncWork.Tests/ExtensionMethods/SiloHostBuilderExtensionsTests.cs
@@ -1,19 +1,39 @@
-﻿using FluentAssertions;
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Orleans.Hosting;
+using Orleans.SyncWork.Demo.Services.Grains;
+using Orleans.SyncWork.ExtensionMethods;
+using Orleans.SyncWork.Tests.TestGrains;
+using Orleans.TestingHost;
 using Xunit;
 
 namespace Orleans.SyncWork.Tests.ExtensionMethods;
 
 public class SiloHostBuilderExtensionsTests
 {
+    [Fact]
+    public void WhenNotCallingConfigure_ShouldNotResolveLimitedConcurrencyScheduler()
+    {
+        var builder = new SiloHostBuilder();
+
+        builder.UseLocalhostClustering();
+            
+        var host = builder.Build();
+        var scheduler = (LimitedConcurrencyLevelTaskScheduler)host.Services.GetService(typeof(LimitedConcurrencyLevelTaskScheduler));
+
+        scheduler.Should().BeNull("The extension method was not used to register the scheduler");
+    }
+    
     [Theory]
     [InlineData(4)]
     [InlineData(8)]
     public void WhenCallingConfigure_ShouldRegisterLimitedConcurrencyScheduler(int maxSyncWorkConcurrency)
     {
         var builder = new SiloHostBuilder();
-        Orleans.SyncWork.ExtensionMethods.SiloHostBuilderExtensions.ConfigureSyncWorkAbstraction(builder, maxSyncWorkConcurrency);
+        builder.ConfigureSyncWorkAbstraction(maxSyncWorkConcurrency);
 
         builder.UseLocalhostClustering();
             

--- a/test/Orleans.SyncWork.Tests/Orleans.SyncWork.Tests.csproj
+++ b/test/Orleans.SyncWork.Tests/Orleans.SyncWork.Tests.csproj
@@ -9,6 +9,13 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.5.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Orleans.Core" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="3.5.1" />
     <PackageReference Include="Microsoft.Orleans.TestingHost" Version="3.5.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/Orleans.SyncWork.Tests/TestGrains/TestGrain.cs
+++ b/test/Orleans.SyncWork.Tests/TestGrains/TestGrain.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+
+namespace Orleans.SyncWork.Tests.TestGrains;
+
+public interface ITestGrain : IGrain, IGrainWithGuidKey
+{
+    Task<string> Get();
+}
+
+public class TestGrain : Grain, ITestGrain
+{
+    public Task<string> Get()
+    {
+        return Task.FromResult(
+            "This is a test grain so that the test project has a grain that can be resolved (that isn't a sync-work grain) when setting up a test cluster");
+    }
+}


### PR DESCRIPTION
* When utilizing this package externally, was running into issues with clients not successfully getting instances of grains that were extending SyncWorker
  * This extension method's equivalent corrected that issue externally, so added it to the package itself as an extension method