### PR TITLE
Updates `GetWorkStatus` to throw in instances of "NotStarted".

### DIFF
--- a/src/Orleans.SyncWork/Exceptions/InvalidStateException.cs
+++ b/src/Orleans.SyncWork/Exceptions/InvalidStateException.cs
@@ -10,8 +10,11 @@ namespace Orleans.SyncWork.Exceptions;
 /// </summary>
 public class InvalidStateException : Exception
 {
+    public InvalidStateException(string message) : base(message) { }
+    
+    public InvalidStateException(SyncWorkStatus unexpectedStatus) : base(
+        $"Grain was in an invalid state of {unexpectedStatus}.") { }
+    
     public InvalidStateException(SyncWorkStatus actualStatus, SyncWorkStatus expectedStatus) : base(
-        $"Grain was in an invalid state for the requested grain method.  Expected status {expectedStatus}, got {actualStatus}.")
-    {
-    }
+        $"Grain was in an invalid state for the requested grain method.  Expected status {expectedStatus}, got {actualStatus}.") { }
 }

--- a/src/Orleans.SyncWork/SyncWorker.cs
+++ b/src/Orleans.SyncWork/SyncWorker.cs
@@ -36,11 +36,11 @@ public abstract class SyncWorker<TRequest, TResult> : Grain, ISyncWorker<TReques
     {
         if (_task != null)
         {
-            _logger.LogDebug($"{nameof(Start)}: Task already initialized upon call.");
+            _logger.LogDebug("{nameof(Start)}: Task already initialized upon call.", nameof(Start));
             return Task.FromResult(false);
         }
 
-        _logger.LogDebug($"{nameof(Start)}: Starting task, set status to running.");
+        _logger.LogDebug("{nameof(Start)}: Starting task, set status to running.", nameof(Start));
         _status = SyncWorkStatus.Running;
         _task = CreateTask(request);
 
@@ -50,6 +50,13 @@ public abstract class SyncWorker<TRequest, TResult> : Grain, ISyncWorker<TReques
     /// <inheritdoc />
     public Task<SyncWorkStatus> GetWorkStatus()
     {
+        if (_status == SyncWorkStatus.NotStarted)
+        {
+            _logger.LogError("{nameof(GetWorkStatus} was in a status of {SyncWorkStatus.NotStarted}", nameof(GetWorkStatus), SyncWorkStatus.NotStarted);
+            DeactivateOnIdle();
+            throw new InvalidStateException(_status);
+        }
+        
         return Task.FromResult(_status);
     }
 
@@ -58,7 +65,8 @@ public abstract class SyncWorker<TRequest, TResult> : Grain, ISyncWorker<TReques
     {
         if (_status != SyncWorkStatus.Faulted)
         {
-            _logger.LogError("{nameof(this.GetException)}: Attempting to retrieve exception from grain when grain not in a faulted state ({_status}).", nameof(this.GetException), _status);
+            _logger.LogError("{nameof(GetException)}: Attempting to retrieve exception from grain when grain not in a faulted state ({_status}).", nameof(GetException), _status);
+            DeactivateOnIdle();
             throw new InvalidStateException(_status, SyncWorkStatus.Faulted);
         }
 
@@ -73,12 +81,13 @@ public abstract class SyncWorker<TRequest, TResult> : Grain, ISyncWorker<TReques
     {
         if (_status != SyncWorkStatus.Completed)
         {
-            _logger.LogError("{nameof(this.GetResult)}: Attempting to retrieve result from grain when grain not in a completed state ({_status}).", nameof(this.GetResult), _status);
+            _logger.LogError("{nameof(GetResult)}: Attempting to retrieve result from grain when grain not in a completed state ({_status}).", nameof(GetResult), _status);
+            DeactivateOnIdle();
             throw new InvalidStateException(_status, SyncWorkStatus.Completed);
         }
 
         _task = null;
-        this.DeactivateOnIdle();
+        DeactivateOnIdle();
 
         return Task.FromResult(_result);
     }
@@ -101,15 +110,15 @@ public abstract class SyncWorker<TRequest, TResult> : Grain, ISyncWorker<TReques
         {
             try
             {
-                _logger.LogInformation($"{nameof(this.CreateTask)}: Beginning work for task.");
+                _logger.LogInformation("{nameof(CreateTask)}: Beginning work for task.", nameof(CreateTask));
                 _result = await PerformWork(request);
                 _exception = default;
                 _status = SyncWorkStatus.Completed;
-                _logger.LogInformation($"{nameof(this.CreateTask)}: Completed work for task.");
+                _logger.LogInformation("{nameof(CreateTask)}: Completed work for task.", nameof(CreateTask));
             }
             catch (Exception e)
             {
-                _logger.LogError(e, $"{nameof(this.CreateTask)}: Exception during task.");
+                _logger.LogError(e, "{nameof(CreateTask)}: Exception during task.", nameof(CreateTask));
                 _result = default;
                 _exception = e;
                 _status = SyncWorkStatus.Faulted;

--- a/src/Orleans.SyncWork/SyncWorkerExtensions.cs
+++ b/src/Orleans.SyncWork/SyncWorkerExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Orleans.SyncWork.Enums;
+using Orleans.SyncWork.Exceptions;
 
 namespace Orleans.SyncWork;
 
@@ -61,7 +62,7 @@ public static class SyncWorkerExtensions
                     var exception = await worker.GetException();
                     throw exception;
                 case SyncWorkStatus.NotStarted:
-                    throw new Exception("This shouldn't happen, but if it does, I'm assuming it means the cluster may have died, or a timeout occurred and the grain got reinstantiated without firing off the work.");
+                    throw new InvalidStateException("This shouldn't happen, but if it does, it probably means the cluster may have died and restarted, and/or a timeout occurred and the grain got reinstantiated without firing off the work.");
                 default:
                     throw new Exception("How did we even get here...?");
             }


### PR DESCRIPTION
* It is intended for the work to be `Started` prior to checking on its status.
  * Doing this throw in cases where the work status is not started will potentially help consumers realize that work was "lost" in cases where the node in which the work was being performed died.
* Updated some additional structured logging messages.
* Added additional constructors to the `InvalidStateException` to account for other scenarios of the exception being thrown.