### PR TITLE
Adds new `ISiloBuilder` extension method

### DIFF
--- a/samples/Orleans.SyncWork.Demo.Api.Benchmark/BenchmarkingSiloHost.cs
+++ b/samples/Orleans.SyncWork.Demo.Api.Benchmark/BenchmarkingSiloHost.cs
@@ -1,16 +1,21 @@
 ﻿using System.Threading.Tasks;
 using Orleans.Hosting;
+using Orleans.SyncWork.Tests.TestClusters;
+using Orleans.TestingHost;
 
 namespace Orleans.SyncWork.Demo.Api.Benchmark;
 
-internal static class BenchmarkingSIloHost
+internal static class BenchmarkingSiloHost
 {
-    static ISiloHost _siloHost;
-    public static async Task<ISiloHost> GetSiloHost()
+    static TestCluster _testCluster;
+    public static TestCluster GetTestCluster()
     {
-        if (_siloHost == null)
-            _siloHost = await OrleansConfigurationHelper.StartSilo();
+        if (_testCluster == null)
+        {
+            var clusterFixture = new ClusterFixture();
+            _testCluster = clusterFixture.Cluster;
+        }
 
-        return _siloHost;
+        return _testCluster;
     }
 }

--- a/samples/Orleans.SyncWork.Demo.Api.Benchmark/Benchy.cs
+++ b/samples/Orleans.SyncWork.Demo.Api.Benchmark/Benchy.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using Microsoft.Extensions.DependencyInjection;
 using Orleans.SyncWork.Demo.Services;
 using Orleans.SyncWork.Demo.Services.Grains;
 
@@ -12,7 +11,7 @@ public class Benchy
 {
     const int TotalNumberPerBenchmark = 100;
     private readonly IPasswordVerifier _passwordVerifier = new Services.PasswordVerifier();
-    private readonly PasswordVerifierRequest _request = new PasswordVerifierRequest()
+    private readonly PasswordVerifierRequest _request = new()
     {
         Password = PasswordConstants.Password,
         PasswordHash = PasswordConstants.PasswordHash
@@ -55,8 +54,8 @@ public class Benchy
     [Benchmark]
     public async Task OrleansTasks()
     {
-        var siloHost = await BenchmarkingSIloHost.GetSiloHost();
-        var grainFactory = siloHost.Services.GetRequiredService<IGrainFactory>();
+        var grainFactory = BenchmarkingSiloHost.GetTestCluster().GrainFactory;
+
         var tasks = new List<Task>();
         for (var i = 0; i < TotalNumberPerBenchmark; i++)
         {

--- a/samples/Orleans.SyncWork.Demo.Api.Benchmark/Orleans.SyncWork.Demo.Api.Benchmark.csproj
+++ b/samples/Orleans.SyncWork.Demo.Api.Benchmark/Orleans.SyncWork.Demo.Api.Benchmark.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\test\Orleans.SyncWork.Tests\Orleans.SyncWork.Tests.csproj" />
     <ProjectReference Include="..\Orleans.SyncWork.Demo.Api\Orleans.SyncWork.Demo.Api.csproj" />
   </ItemGroup>
 

--- a/samples/Orleans.SyncWork.Demo.Api.Benchmark/Program.cs
+++ b/samples/Orleans.SyncWork.Demo.Api.Benchmark/Program.cs
@@ -1,4 +1,6 @@
 ﻿using BenchmarkDotNet.Running;
 using Orleans.SyncWork.Demo.Api.Benchmark;
 
+BenchmarkingSiloHost.GetTestCluster();
+
 BenchmarkRunner.Run<Benchy>();

--- a/samples/Orleans.SyncWork.Demo.Api/OrleansConfigurationHelper.cs
+++ b/samples/Orleans.SyncWork.Demo.Api/OrleansConfigurationHelper.cs
@@ -1,13 +1,14 @@
-﻿using System;
-using System.Net;
-using System.Threading.Tasks;
+﻿using System.Net;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.SyncWork.Demo.Services;
 using Orleans.SyncWork.Demo.Services.Grains;
 using Orleans.SyncWork.ExtensionMethods;
+using PasswordVerifier = Orleans.SyncWork.Demo.Services.PasswordVerifier;
 
 namespace Orleans.SyncWork.Demo.Api
 {
@@ -17,54 +18,32 @@ namespace Orleans.SyncWork.Demo.Api
         /// Starts a <see cref="ISiloHost"/> with default-ish options.
         /// </summary>
         /// <returns>The started <see cref="ISiloHost"/>.</returns>
-        public static async Task<ISiloHost> StartSilo()
+        public static ConfigureHostBuilder ConfigureOrleans(this ConfigureHostBuilder builder, int maxSyncWorkConcurrency)
         {
-            var builder = new SiloHostBuilder();
-            ConfigureSiloHostBuilder(builder);
-
-            var host = builder.Build();
-            await host.StartAsync();
-            return host;
-        }
-
-        /// <summary>
-        /// Configures the <see cref="ISiloHostBuilder"/> with a default amount of concurrent work (<see cref="Environment.ProcessorCount"/> - 2).
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <returns>The <see cref="ISiloHostBuilder"/>.</returns>
-        public static ISiloHostBuilder ConfigureSiloHostBuilder(this ISiloHostBuilder builder)
-        {
-            return builder.ConfigureSiloHostBuilder(Environment.ProcessorCount - 2);
-        }
-
-        /// <summary>
-        /// Configures the <see cref="ISiloHostBuilder"/> with a specified amount of concurrent work.
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="maxSyncWorkConcurrency">The maximum amount of concurrent work for each node of the cluster to take on at a time.</param>
-        /// <returns>The <see cref="ISiloHostBuilder"/>.</returns>
-        public static ISiloHostBuilder ConfigureSiloHostBuilder(this ISiloHostBuilder builder, int maxSyncWorkConcurrency)
-        {
-            builder
-                .UseLocalhostClustering()
-                .Configure<ClusterOptions>(options =>
-                {
-                    options.ClusterId = "dev";
-                    options.ServiceId = "HelloWorldApp";
-                })
-                .Configure<EndpointOptions>(options => options.AdvertisedIPAddress = IPAddress.Loopback)
-                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IHelloWorld).Assembly).WithReferences())
-                .ConfigureSyncWorkAbstraction(maxSyncWorkConcurrency)
-                .ConfigureLogging(logging => logging.AddConsole())
-                .UseDashboard(config =>
-                {
-                    config.Port = 8081;
-                });
-
-            builder.ConfigureServices(services =>
+            builder.UseOrleans((siloBuilder) =>
             {
-                services.AddSingleton<IPasswordVerifier, Services.PasswordVerifier>();
+                siloBuilder
+                    .UseLocalhostClustering()
+                    .Configure<ClusterOptions>(options =>
+                    {
+                        options.ClusterId = "dev";
+                        options.ServiceId = "HelloWorldApp";
+                    })
+                    .Configure<EndpointOptions>(options => options.AdvertisedIPAddress = IPAddress.Loopback)
+                    .ConfigureApplicationParts(parts =>
+                        parts.AddApplicationPart(typeof(IHelloWorld).Assembly).WithReferences())
+                    .ConfigureSyncWorkAbstraction(maxSyncWorkConcurrency)
+                    .ConfigureLogging(logging => logging.AddConsole())
+                    .ConfigureServices(collection =>
+                    {
+                        collection.AddSingleton<IPasswordVerifier, PasswordVerifier>();
+                    })
+                    .UseDashboard(config =>
+                    {
+                        config.Port = 8081;
+                    });
             });
+            
             return builder;
         }
     }

--- a/samples/Orleans.SyncWork.Demo.Api/OrleansConfigurationHelper.cs
+++ b/samples/Orleans.SyncWork.Demo.Api/OrleansConfigurationHelper.cs
@@ -43,7 +43,7 @@ namespace Orleans.SyncWork.Demo.Api
                         config.Port = 8081;
                     });
             });
-            
+
             return builder;
         }
     }

--- a/samples/Orleans.SyncWork.Demo.Api/Program.cs
+++ b/samples/Orleans.SyncWork.Demo.Api/Program.cs
@@ -11,14 +11,12 @@ using Orleans.SyncWork.Demo.Api;
 using Orleans.SyncWork.Demo.Services.Grains;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Host.ConfigureOrleans(Environment.ProcessorCount - 2);
 
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-
-var orleans = await OrleansConfigurationHelper.StartSilo();
-builder.Services.AddSingleton(orleans);
 
 var app = builder.Build();
 
@@ -28,7 +26,7 @@ app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 
-var grainFactory = orleans.Services.GetRequiredService<IGrainFactory>();
+var grainFactory = app.Services.GetRequiredService<IGrainFactory>();
 
 app
     .MapGet("/helloWorld", async (string name) =>

--- a/src/Orleans.SyncWork/ExtensionMethods/SiloBuilderExtensions.cs
+++ b/src/Orleans.SyncWork/ExtensionMethods/SiloBuilderExtensions.cs
@@ -1,18 +1,17 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Orleans.Hosting;
 
 namespace Orleans.SyncWork.ExtensionMethods;
 
 /// <summary>
-/// Extension methods for <see cref="ISiloHostBuilder"/>.
+/// Extension methods for <see cref="ISiloBuilder"/>.
 /// </summary>
-public static class SiloHostBuilderExtensions
+public static class SiloBuilderExtensions
 {
     /// <summary>
     /// Configures assembly scanning against this assembly containing the <see cref="ISyncWorker{TRequest, TResult}"/>.
     /// </summary>
-    /// <param name="builder">The <see cref="ISiloHostBuilder"/> instance.</param>
+    /// <param name="builder">The <see cref="ISiloBuilder"/> instance.</param>
     /// <param name="maxSyncWorkConcurrency">
     ///     The maximum amount of concurrent work to perform at a time.  
     ///     The CPU cannot be "tapped out" with concurrent work lest Orleans experience timeouts.
@@ -22,8 +21,8 @@ public static class SiloHostBuilderExtensions
     ///     A "general" rule of thumb that I've had success with is using "Environment.ProcessorCount - 2" as the max concurrency.
     /// 
     /// </remarks>
-    /// <returns>The <see cref="ISiloHostBuilder"/> to allow additional fluent API chaining.</returns>
-    public static ISiloHostBuilder ConfigureSyncWorkAbstraction(this ISiloHostBuilder builder, int maxSyncWorkConcurrency = 4)
+    /// <returns>The <see cref="ISiloBuilder"/> to allow additional fluent API chaining.</returns>
+    public static ISiloBuilder ConfigureSyncWorkAbstraction(this ISiloBuilder builder, int maxSyncWorkConcurrency = 4)
     {
         builder.ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(ISyncWorkAbstractionMarker).Assembly).WithReferences());
 

--- a/src/Orleans.SyncWork/Orleans.SyncWork.csproj
+++ b/src/Orleans.SyncWork/Orleans.SyncWork.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/test/Orleans.SyncWork.Tests/ExtensionMethods/SiloBuilderExtensionsTests.cs
+++ b/test/Orleans.SyncWork.Tests/ExtensionMethods/SiloBuilderExtensionsTests.cs
@@ -1,0 +1,42 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+using Orleans.Hosting;
+using Orleans.SyncWork.ExtensionMethods;
+using Xunit;
+
+namespace Orleans.SyncWork.Tests.ExtensionMethods;
+
+public class SiloBuilderExtensionsTests
+{
+    [Fact]
+    public void WhenNotCallingConfigure_ShouldNotResolveLimitedConcurrencyScheduler()
+    {
+        var builder = new HostBuilder()
+            .UseOrleans(siloBuilder => siloBuilder.UseLocalhostClustering());
+
+        var host = builder.Build();
+        var scheduler = (LimitedConcurrencyLevelTaskScheduler)host.Services.GetService(typeof(LimitedConcurrencyLevelTaskScheduler));
+
+        scheduler.Should().BeNull("The extension method was not used to register the scheduler");
+    }
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(8)]
+    public void WhenCallingConfigure_ShouldRegisterLimitedConcurrencyScheduler(int maxSyncWorkConcurrency)
+    {
+        var builder = new HostBuilder()
+            .UseOrleans(builder =>
+            {
+                builder.ConfigureSyncWorkAbstraction(maxSyncWorkConcurrency);        
+                builder.UseLocalhostClustering();
+            });
+
+        var host = builder.Build();
+        var scheduler = (LimitedConcurrencyLevelTaskScheduler)host.Services.GetService(typeof(LimitedConcurrencyLevelTaskScheduler));
+
+        scheduler.Should().NotBeNull("the extension method was to registered the scheduler");
+        scheduler?.MaximumConcurrencyLevel.Should().Be(maxSyncWorkConcurrency,
+            "the scheduler should have the registered level of maximum concurrency");
+    }
+}

--- a/test/Orleans.SyncWork.Tests/ExtensionMethods/SiloBuilderExtensionsTests.cs
+++ b/test/Orleans.SyncWork.Tests/ExtensionMethods/SiloBuilderExtensionsTests.cs
@@ -28,7 +28,7 @@ public class SiloBuilderExtensionsTests
         var builder = new HostBuilder()
             .UseOrleans(builder =>
             {
-                builder.ConfigureSyncWorkAbstraction(maxSyncWorkConcurrency);        
+                builder.ConfigureSyncWorkAbstraction(maxSyncWorkConcurrency);
                 builder.UseLocalhostClustering();
             });
 


### PR DESCRIPTION
# Description

Adds new `ISiloBuilder` extension method that can be used with the `UseOrleans` extension method on top of `IHostBuilder`
  * https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostbuilder?view=dotnet-plat-ext-6.0

Fixes #33

## Type of Change

* [ ] Bug fix
* [x] New Feature
* [ ] Documentation
* [x] Code improvement
* [ ] Breaking change - if a public API changes, or any change that ***DOES*** or ***MAY*** require a major revision to the NuGet package version due to [semver](https://semver.org/).
* [x] Unit tests
* [ ] Code samples
* [ ] Added your repository URL to the readme because you make use of this super cool package! ;)
* [ ] Other

## Describe testing that was performed for your change

Added new unit tests mirroring the tests against `ISiloHostBuilder`s extension methods

## Checklist

* [x] Read the https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/CONTRIBUTING.md
* [x] Ran unit tests and ensured they passed
* [x] Added unit tests where applicable
* [x] Referenced an issue where applicable
* [x] Ran `dotnet-format` locally
