### PR TITLE
Fixes typo in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,6 @@ Use an `x` in between the `[ ]` for each line applicable to the type of change f
 * [ ] Bug fix
 * [ ] New Feature
 * [ ] Documentation
-* [ ] Code improvment
 * [ ] Code improvement
 * [ ] Breaking change - if a public API changes, or any change that ***DOES*** or ***MAY*** require a major revision to the NuGet package version due to [semver](https://semver.org/).
 * [ ] Unit tests


### PR DESCRIPTION
# Description

Fixes a typo in this PR template by removing `* [ ] Code improvment`, as it was also a duplicate...

## Type of Change

Use an `x` in between the `[ ]` for each line applicable to the type of change for this PR

* [x] Bug fix
* [ ] New Feature
* [x] Documentation
* [ ] Code improvement
* [ ] Breaking change - if a public API changes, or any change that ***DOES*** or ***MAY*** require a major revision to the NuGet package version due to [semver](https://semver.org/).
* [ ] Unit tests
* [ ] Code samples
* [ ] Added your repository URL to the readme because you make use of this super cool package! ;)
* [ ] Other

Please describe if other

## Checklist

* [x] Read the https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/CONTRIBUTING.md
* [ ] Ran unit tests and ensured they passed
* [ ] Added unit tests where applicable
* [ ] Referenced an issue where applicable
* [ ] Ran `dotnet-format` locally
