### PR TITLE
Adds cancellation token support for long running work grains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build and test](https://github.com/OrleansContrib/Orleans.SyncWork/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/OrleansContrib/Orleans.SyncWork/actions/workflows/ci.yml) [![Coverage Status](https://coveralls.io/repos/github/OrleansContrib/Orleans.SyncWork/badge.svg?branch=main)](https://coveralls.io/github/OrleansContrib/Orleans.SyncWork?branch=main)
 
-![Latest NuGet Version](https://img.shields.io/nuget/v/Orleans.SyncWork) 
+![Latest NuGet Version](https://img.shields.io/nuget/v/Orleans.SyncWork)
 ![License](https://img.shields.io/github/license/OrleansContrib/Orleans.SyncWork)
 
 This package's intention is to expose an abstract base class to allow [Orleans](https://github.com/dotnet/orleans/) to work with long running, CPU bound, synchronous work, without becoming overloaded.
@@ -13,10 +13,10 @@ The project was built primarily with .net3 in mind, though the varying major ver
 
 ### Requirements
 
-* [.net 6.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
-* [.net 7.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
-* [.net 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
-* [dotnet-format](https://github.com/dotnet/format)
+- [.net 6.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+- [.net 7.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
+- [.net 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+- [dotnet-format](https://github.com/dotnet/format)
 
 ## Project Overview
 
@@ -24,37 +24,38 @@ There are several projects within this repository, all with the idea of demonstr
 
 The projects in this repository include:
 
-* [Orleans.SyncWork](#orleanssyncwork)
-* [Orleans.SyncWork.Tests](#orleanssyncworktests)
-* [Orleans.SyncWork.Demo.Api](#orleanssyncworkdemoapi)
-* [Orleans.SyncWork.Demo.Api.Benchmark](#orleanssyncworkdemoapibenchmark)
-* [Orleans.SyncWork.Demo.Services](#orleanssyncworkdemoservices)
+- [Orleans.SyncWork](#orleanssyncwork)
+- [Orleans.SyncWork.Tests](#orleanssyncworktests)
+- [Orleans.SyncWork.Demo.Api](#orleanssyncworkdemoapi)
+- [Orleans.SyncWork.Demo.Api.Benchmark](#orleanssyncworkdemoapibenchmark)
+- [Orleans.SyncWork.Demo.Services](#orleanssyncworkdemoservices)
 
 ### Orleans.SyncWork
 
-The meat and potatoes of the project.  This project contains the abstraction of "Long Running, CPU bound, Synchronous work" in the form of an abstract base class [SyncWorker](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/SyncWorker.cs); which implements an interface [ISyncWorker](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/ISyncWorker.cs).
+The meat and potatoes of the project. This project contains the abstraction of "Long Running, CPU bound, Synchronous work" in the form of an abstract base class [SyncWorker](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/SyncWorker.cs); which implements an interface [ISyncWorker](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/ISyncWorker.cs).
 
-When long running work is identified, you can extend the base class `SyncWorker`, providing a `TRequest` and `TResponse` unique to the long running work.  This allows you to create as many `ISyncWork<TRequest, TResponse>` implementations as necessary, for all your long running CPU bound needs! (At least that is the hope.)
+When long running work is identified, you can extend the base class `SyncWorker`, providing a `TRequest` and `TResponse` unique to the long running work. This allows you to create as many `ISyncWork<TRequest, TResponse>` implementations as necessary, for all your long running CPU bound needs! (At least that is the hope.)
 
 Basic "flow" of the SyncWork:
 
-* `Start`
-* Poll `GetStatus` until a `Completed` or `Faulted` status is received
-* `GetResult` or `GetException` depending on the `GetStatus`
+- `Start`
+- Poll `GetStatus` until a `Completed` or `Faulted` status is received
+- `GetResult` or `GetException` depending on the `GetStatus`
 
 This package introduces a few "requirements" against Orleans:
 
-* In order to not overload Orleans, a `LimitedConcurrencyLevelTaskScheduler` is introduced. This task scheduler is registered (either manually or through the provided extension method) with a maximum level of concurrency for the silo being set up.  This maximum concurrency ***MUST*** allow for idle threads, lest the Orleans server be overloaded.  In testing, the general rule of thumb was `Environment.ProcessorCount - 2` max concurrency.  The important part is that the CPU is not fully "tapped out" such that the normal Orleans asynchronous messaging can't make it through due to the blocking sync work - this will make things start timing out.
-* Blocking grains are stateful, and are currently keyed on a Guid.  If in a situation where multiple grains of long running work is needed, each grain should be initialized with its own unique identity.
-* Blocking grains *likely* ***CAN NOT*** dispatch further blocking grains.  This is not yet tested under the repository, but it stands to reason that with a limited concurrency scheduler, the following scenario would lead to a deadlock:
-    * Grain A is long running
-    * Grain B is long running
-    * Grain A initializes and fires off Grain B
-    * Grain A cannot complete its work until it gets the results of Grain B
+- In order to not overload Orleans, a `LimitedConcurrencyLevelTaskScheduler` is introduced. This task scheduler is registered (either manually or through the provided extension method) with a maximum level of concurrency for the silo being set up. This maximum concurrency **_MUST_** allow for idle threads, lest the Orleans server be overloaded. In testing, the general rule of thumb was `Environment.ProcessorCount - 2` max concurrency. The important part is that the CPU is not fully "tapped out" such that the normal Orleans asynchronous messaging can't make it through due to the blocking sync work - this will make things start timing out.
+- Blocking grains are stateful, and are currently keyed on a Guid. If in a situation where multiple grains of long running work is needed, each grain should be initialized with its own unique identity.
+- Blocking grains _likely_ **_CAN NOT_** dispatch further blocking grains. This is not yet tested under the repository, but it stands to reason that with a limited concurrency scheduler, the following scenario would lead to a deadlock:
 
-    In the above scenario, if "Grain A" is "actively being worked" and it fires off a "Grain B", but "Grain A" cannot complete its work until "Grain B" finishes its own, but "Grain B" cannot *start* its work until "Grain A" finishes its work due to limited concurrency, you've run into a situation where the limited concurrency task scheduler can never finish the work of "Grain A".
-    
-    That was quite a sentence, hopefully the point was conveyed somewhat sensibly. There may be a way to avoid the above scenario, but I have not yet deeply explored it.
+  - Grain A is long running
+  - Grain B is long running
+  - Grain A initializes and fires off Grain B
+  - Grain A cannot complete its work until it gets the results of Grain B
+
+  In the above scenario, if "Grain A" is "actively being worked" and it fires off a "Grain B", but "Grain A" cannot complete its work until "Grain B" finishes its own, but "Grain B" cannot _start_ its work until "Grain A" finishes its work due to limited concurrency, you've run into a situation where the limited concurrency task scheduler can never finish the work of "Grain A".
+
+  That was quite a sentence, hopefully the point was conveyed somewhat sensibly. There may be a way to avoid the above scenario, but I have not yet deeply explored it.
 
 #### Usage
 
@@ -66,14 +67,15 @@ public class PasswordVerifier : SyncWorker<PasswordVerifierRequest, PasswordVeri
     private readonly IPasswordVerifier _passwordVerifier;
 
     public PasswordVerifier(
-        ILogger<PasswordVerifier> logger, 
-        LimitedConcurrencyLevelTaskScheduler limitedConcurrencyLevelTaskScheduler, 
+        ILogger<PasswordVerifier> logger,
+        LimitedConcurrencyLevelTaskScheduler limitedConcurrencyLevelTaskScheduler,
         IPasswordVerifier passwordVerifier) : base(logger, limitedConcurrencyLevelTaskScheduler)
     {
         _passwordVerifier = passwordVerifier;
     }
 
-    protected override async Task<PasswordVerifierResult> PerformWork(PasswordVerifierRequest request)
+    protected override async Task<PasswordVerifierResult> PerformWork(
+        PasswordVerifierRequest request, GrainCancellationToken grainCancellationToken)
     {
         var verifyResult = await _passwordVerifier.VerifyPassword(request.PasswordHash, request.Password);
 
@@ -83,6 +85,7 @@ public class PasswordVerifier : SyncWorker<PasswordVerifierRequest, PasswordVeri
         };
     }
 }
+
 public class PasswordVerifierRequest
 {
     public string Password { get; set; }
@@ -107,11 +110,11 @@ var passwordVerifyGrain = grainFactory.GetGrain<ISyncWorker<PasswordVerifierRequ
 var result = await passwordVerifyGrain.StartWorkAndPollUntilResult(request);
 ```
 
-The above `StartWorkAndPollUntilResult` is an extension method defined in the package ([SyncWorkerExtensions](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/SyncWorkerExtensions.cs)) that `Start`s, `Poll`s, and finally `GetResult` or `GetException` upon completed work.  There would seemingly be place for improvement here as it relates to testing unexpected scenarios, configuration based polling, etc.
+The above `StartWorkAndPollUntilResult` is an extension method defined in the package ([SyncWorkerExtensions](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/SyncWorkerExtensions.cs)) that `Start`s, `Poll`s, and finally `GetResult` or `GetException` upon completed work. There would seemingly be place for improvement here as it relates to testing unexpected scenarios, configuration based polling, etc.
 
 ### Orleans.SyncWork.Tests
 
-Unit testing project for the work in [Orleans.SyncWork](#orleanssyncwork).  These tests bring up a "TestCluster" which is used for the full duration of the tests against the grains.
+Unit testing project for the work in [Orleans.SyncWork](#orleanssyncwork). These tests bring up a "TestCluster" which is used for the full duration of the tests against the grains.
 
 One of the tests in particular throws 10k grains onto the cluster at once, all of which are long running (~200ms each) on my machine - more than enough time to overload the cluster if the limited concurrency task scheduler is not working along side the `SyncWork` base class correctly.
 
@@ -119,9 +122,9 @@ TODO: still could use a few more unit tests here to if nothing else, document be
 
 ### Orleans.SyncWork.Demo.Api
 
-This is a demo of the `ISyncWork<TRequest, TResult>` in action.  This project is being used as both a Orleans Silo, and client.  Generally you would stand up nodes to the cluster separate from the clients against the cluster.  Since we have only one node for testing purposes, this project acts as both the silo host and client.
+This is a demo of the `ISyncWork<TRequest, TResult>` in action. This project is being used as both a Orleans Silo, and client. Generally you would stand up nodes to the cluster separate from the clients against the cluster. Since we have only one node for testing purposes, this project acts as both the silo host and client.
 
-The [OrleansDashboard](https://github.com/OrleansContrib/OrleansDashboard) is also brought up with the API.  You can see an example of hitting an endpoint in which 10k password verification requests are received here:
+The [OrleansDashboard](https://github.com/OrleansContrib/OrleansDashboard) is also brought up with the API. You can see an example of hitting an endpoint in which 10k password verification requests are received here:
 
 ![Dashboard showing 10k CPU bound, long running requests](/docs/images/dashboard.PNG)
 
@@ -197,14 +200,14 @@ public class Benchy
 
 And here are the results:
 
-|                Method |     Mean |    Error |   StdDev |
-|---------------------- |---------:|---------:|---------:|
-|                Serial | 12.399 s | 0.0087 s | 0.0077 s |
-|         MultipleTasks | 12.289 s | 0.0106 s | 0.0094 s |
+| Method                |     Mean |    Error |   StdDev |
+| --------------------- | -------: | -------: | -------: |
+| Serial                | 12.399 s | 0.0087 s | 0.0077 s |
+| MultipleTasks         | 12.289 s | 0.0106 s | 0.0094 s |
 | MultipleParallelTasks |  1.749 s | 0.0347 s | 0.0413 s |
-|          OrleansTasks |  2.130 s | 0.0055 s | 0.0084 s |
+| OrleansTasks          |  2.130 s | 0.0055 s | 0.0084 s |
 
-And of course note, that in the above the Orleans tasks are *limited* to my local cluster.  In a more real situation where you have multiple nodes to the cluster, you could expect to get better timing, though you'd probably have to deal more with network latency.
+And of course note, that in the above the Orleans tasks are _limited_ to my local cluster. In a more real situation where you have multiple nodes to the cluster, you could expect to get better timing, though you'd probably have to deal more with network latency.
 
 ### Orleans.SyncWork.Demo.Services
 

--- a/samples/Orleans.SyncWork.Demo.Services/Grains/CancellableGrain.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/Grains/CancellableGrain.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Orleans.SyncWork.Demo.Services.Grains;
+
+public class CancellableGrain : SyncWorker<SampleCancellationRequest, SampleCancellationResult>
+{
+    public CancellableGrain(
+        ILogger<CancellableGrain> logger,
+        LimitedConcurrencyLevelTaskScheduler limitedConcurrencyScheduler) : base(logger, limitedConcurrencyScheduler)
+    {
+    }
+
+    protected override async Task<SampleCancellationResult> PerformWork(
+        SampleCancellationRequest request, GrainCancellationToken grainCancellationToken)
+    {
+        var startingValue = request.StartingValue;
+
+        for (var i = 0; i < request.EnumerationMax; i++)
+        {
+            if (grainCancellationToken.CancellationToken.IsCancellationRequested)
+            {
+                Logger.LogInformation("Task cancelled on iteration {Iteration}", i);
+
+                if (request.ThrowOnCancel)
+                    throw new OperationCanceledException(grainCancellationToken.CancellationToken);
+                
+                return new SampleCancellationResult() {EndingValue = startingValue};
+            }
+
+            startingValue += 1;
+            await Task.Delay(request.EnumerationDelay);
+        }
+
+        return new SampleCancellationResult() { EndingValue = startingValue };
+    }
+}
+
+[GenerateSerializer]
+public class SampleCancellationRequest
+{
+    [Id(0)]
+    public TimeSpan EnumerationDelay { get; init; }
+    [Id(1)]
+    public int StartingValue { get; init; }
+    [Id(2)]
+    public int EnumerationMax { get; init; } = 1_000;
+    [Id(3)] 
+    public bool ThrowOnCancel { get; init; }
+}
+
+[GenerateSerializer]
+public class SampleCancellationResult
+{
+    [Id(0)]
+    public int EndingValue { get; init; }
+}

--- a/samples/Orleans.SyncWork.Demo.Services/Grains/CancellableGrain.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/Grains/CancellableGrain.cs
@@ -25,8 +25,8 @@ public class CancellableGrain : SyncWorker<SampleCancellationRequest, SampleCanc
 
                 if (request.ThrowOnCancel)
                     throw new OperationCanceledException(grainCancellationToken.CancellationToken);
-                
-                return new SampleCancellationResult() {EndingValue = startingValue};
+
+                return new SampleCancellationResult() { EndingValue = startingValue };
             }
 
             startingValue += 1;
@@ -46,7 +46,7 @@ public class SampleCancellationRequest
     public int StartingValue { get; init; }
     [Id(2)]
     public int EnumerationMax { get; init; } = 1_000;
-    [Id(3)] 
+    [Id(3)]
     public bool ThrowOnCancel { get; init; }
 }
 

--- a/samples/Orleans.SyncWork.Demo.Services/Grains/ICancellableGrain.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/Grains/ICancellableGrain.cs
@@ -1,4 +1,4 @@
 ﻿namespace Orleans.SyncWork.Demo.Services.Grains;
 
-public interface ICancellableGrain 
+public interface ICancellableGrain
     : ISyncWorker<SampleCancellationRequest, SampleCancellationResult>, IGrainWithGuidKey;

--- a/samples/Orleans.SyncWork.Demo.Services/Grains/PasswordVerifier.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/Grains/PasswordVerifier.cs
@@ -15,7 +15,8 @@ public class PasswordVerifier : SyncWorker<PasswordVerifierRequest, PasswordVeri
         _passwordVerifier = passwordVerifier;
     }
 
-    protected override async Task<PasswordVerifierResult> PerformWork(PasswordVerifierRequest request)
+    protected override async Task<PasswordVerifierResult> PerformWork(
+        PasswordVerifierRequest request, GrainCancellationToken grainCancellationToken)
     {
         var verifyResult = await _passwordVerifier.VerifyPassword(request.PasswordHash, request.Password);
 

--- a/samples/Orleans.SyncWork.Demo.Services/TestGrains/GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/TestGrains/GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable.cs
@@ -29,7 +29,8 @@ public class GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable : Sync
         LimitedConcurrencyLevelTaskScheduler limitedConcurrencyScheduler
     ) : base(logger, limitedConcurrencyScheduler) { }
 
-    protected override async Task<TestDelayExceptionResult> PerformWork(TestDelayExceptionRequest request)
+    protected override async Task<TestDelayExceptionResult> PerformWork(
+        TestDelayExceptionRequest request, GrainCancellationToken grainCancellationToken)
     {
         Logger.LogInformation($"Waiting {request.MsDelayPriorToResult} on {this.IdentityString}");
         await Task.Delay(request.MsDelayPriorToResult);

--- a/samples/Orleans.SyncWork.Demo.Services/TestGrains/GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/TestGrains/GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable.cs
@@ -29,7 +29,8 @@ public class GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable : SyncWo
         LimitedConcurrencyLevelTaskScheduler limitedConcurrencyScheduler
     ) : base(logger, limitedConcurrencyScheduler) { }
 
-    protected override async Task<TestDelaySuccessResult> PerformWork(TestDelaySuccessRequest request)
+    protected override async Task<TestDelaySuccessResult> PerformWork(
+        TestDelaySuccessRequest request, GrainCancellationToken grainCancellationToken)
     {
         await Task.Delay(request.MsDelayPriorToResult);
 

--- a/samples/Orleans.SyncWork.Demo.Services/TestGrains/GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/TestGrains/GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable.cs
@@ -20,7 +20,7 @@ public class GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable :
     {
         await Task.Delay(request.MsDelayPriorToResult);
 
-        return new TestDelaySuccessResult() {Started = request.Started, Ended = DateTime.UtcNow};
+        return new TestDelaySuccessResult() { Started = request.Started, Ended = DateTime.UtcNow };
     }
 }
 

--- a/src/Orleans.SyncWork/Enums/SyncWorkStatus.cs
+++ b/src/Orleans.SyncWork/Enums/SyncWorkStatus.cs
@@ -20,5 +20,5 @@ public enum SyncWorkStatus
     /// <summary>
     /// The work has been completed, though an exception was thrown.
     /// </summary>
-    Faulted
+    Faulted,
 }

--- a/src/Orleans.SyncWork/ISyncWorker.cs
+++ b/src/Orleans.SyncWork/ISyncWorker.cs
@@ -18,6 +18,20 @@ public interface ISyncWorker<in TRequest, TResult> : IGrainWithGuidKey
     /// <returns>true if work is started, false if it was already started.</returns>
     Task<bool> Start(TRequest request);
     /// <summary>
+    /// <para>
+    /// Start long running work with the provided parameter.
+    /// </para>
+    /// <para>
+    /// Supports cancellation, but any cancellation logic is up to the grain implementation.  It could
+    /// conceivably return a result at the point of cancellation, or throw, depending on what makes sense for
+    /// the particular grain.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The parameter containing all necessary information to start the workload.</param>
+    /// <param name="grainCancellationToken">The token for cancelling tasks.</param>
+    /// <returns>true if work is started, false if it was already started.</returns>
+    Task<bool> Start(TRequest request, GrainCancellationToken grainCancellationToken);
+    /// <summary>
     /// Gets the long running work status.
     /// </summary>
     /// <returns>The status of the long running work.</returns>

--- a/src/Orleans.SyncWork/SyncWorkerExtensions.cs
+++ b/src/Orleans.SyncWork/SyncWorkerExtensions.cs
@@ -11,9 +11,13 @@ namespace Orleans.SyncWork;
 public static class SyncWorkerExtensions
 {
     /// <summary>
-    /// Starts the work of a <see cref="ISyncWorker{TRequest, TResult}"/>, polls it until a result is available, then returns it.
-    /// 
+    /// <para>
+    /// Starts the work of a <see cref="ISyncWorker{TRequest, TResult}"/>, polls it until a result is available,
+    /// then returns it.
+    /// </para>
+    /// <para>
     /// Polls the <see cref="ISyncWorker{TRequest, TResult}"/> every 1000ms for a result, until one is available.
+    /// </para>
     /// </summary>
     /// <typeparam name="TRequest">The type of request being dispatched.</typeparam>
     /// <typeparam name="TResult">The type of result expected from the work.</typeparam>
@@ -23,7 +27,29 @@ public static class SyncWorkerExtensions
     /// <exception cref="Exception">Thrown when the <see cref="ISyncWorker{TRequest, TResult}"/> is in a <see cref="SyncWorkStatus.Faulted"/> state.</exception>
     public static Task<TResult> StartWorkAndPollUntilResult<TRequest, TResult>(this ISyncWorker<TRequest, TResult> worker, TRequest request)
     {
-        return worker.StartWorkAndPollUntilResult(request, 1000);
+        var grainCancellationToken = new GrainCancellationTokenSource().Token;
+        return worker.StartWorkAndPollUntilResult(request, 1000, grainCancellationToken);
+    }
+
+    /// <summary>
+    /// <para>
+    /// Starts the work of a <see cref="ISyncWorker{TRequest, TResult}"/>, polls it until a result is available,
+    /// then returns it.
+    /// </para>
+    /// <para>
+    /// Polls the <see cref="ISyncWorker{TRequest, TResult}"/> every 1000ms for a result, until one is available.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="TRequest">The type of request being dispatched.</typeparam>
+    /// <typeparam name="TResult">The type of result expected from the work.</typeparam>
+    /// <param name="worker">The <see cref="ISyncWorker{TRequest, TResult}"/> doing the work.</param>
+    /// <param name="request">The request to be dispatched.</param>
+    /// <param name="grainCancellationToken">The token for cancelling tasks.</param>
+    /// <returns>The result of the <see cref="ISyncWorker{TRequest, TResult}"/>.</returns>
+    /// <exception cref="Exception">Thrown when the <see cref="ISyncWorker{TRequest, TResult}"/> is in a <see cref="SyncWorkStatus.Faulted"/> state.</exception>
+    public static Task<TResult> StartWorkAndPollUntilResult<TRequest, TResult>(this ISyncWorker<TRequest, TResult> worker, TRequest request, GrainCancellationToken grainCancellationToken)
+    {
+        return worker.StartWorkAndPollUntilResult(request, 1000, grainCancellationToken);
     }
 
     /// <summary>
@@ -43,6 +69,29 @@ public static class SyncWorkerExtensions
     /// <returns>The result of the <see cref="ISyncWorker{TRequest, TResult}"/>.</returns>
     /// <exception cref="Exception">Thrown when the <see cref="ISyncWorker{TRequest, TResult}"/> is in a <see cref="SyncWorkStatus.Faulted"/> state.</exception>
     public static async Task<TResult> StartWorkAndPollUntilResult<TRequest, TResult>(this ISyncWorker<TRequest, TResult> worker, TRequest request, int msDelayPerStatusPoll)
+    {
+        var grainCancellationToken = new GrainCancellationTokenSource().Token;
+        return await StartWorkAndPollUntilResult(worker, request, msDelayPerStatusPoll, grainCancellationToken);
+    }
+
+    /// <summary>
+    /// Starts the work of a <see cref="ISyncWorker{TRequest, TResult}"/>, polls it until a result is available, then returns it.
+    /// </summary>
+    /// <remarks>
+    ///     Caution is advised when setting the msDelayPerStatusPoll "too low" - 1000 ms seems to be pretty safe, 
+    ///     but if the cluster is under *enough* load, that much grain polling could overwhelm it.
+    /// </remarks>
+    /// <typeparam name="TRequest">The type of request being dispatched.</typeparam>
+    /// <typeparam name="TResult">The type of result expected from the work.</typeparam>
+    /// <param name="worker">The <see cref="ISyncWorker{TRequest, TResult}"/> doing the work.</param>
+    /// <param name="request">The request to be dispatched.</param>
+    /// <param name="msDelayPerStatusPoll">
+    ///     The ms delay per attempt to poll for a <see cref="SyncWorkStatus.Completed"/> or <see cref="SyncWorkStatus.Faulted"/> status.
+    /// </param>
+    /// <param name="grainCancellationToken">The token for cancelling tasks.</param>
+    /// <returns>The result of the <see cref="ISyncWorker{TRequest, TResult}"/>.</returns>
+    /// <exception cref="Exception">Thrown when the <see cref="ISyncWorker{TRequest, TResult}"/> is in a <see cref="SyncWorkStatus.Faulted"/> state.</exception>
+    public static async Task<TResult> StartWorkAndPollUntilResult<TRequest, TResult>(this ISyncWorker<TRequest, TResult> worker, TRequest request, int msDelayPerStatusPoll, GrainCancellationToken grainCancellationToken)
     {
         await worker.Start(request);
         await Task.Delay(100);
@@ -64,7 +113,7 @@ public static class SyncWorkerExtensions
                 case SyncWorkStatus.NotStarted:
                     throw new InvalidStateException("This shouldn't happen, but if it does, it probably means the cluster may have died and restarted, and/or a timeout occurred and the grain got reinstantiated without firing off the work.");
                 default:
-                    throw new Exception("How did we even get here...?");
+                    throw new InvalidStateException("How did we even get here...?");
             }
         }
     }

--- a/test/Orleans.SyncWork.Tests/SyncWorkerTests.cs
+++ b/test/Orleans.SyncWork.Tests/SyncWorkerTests.cs
@@ -310,13 +310,13 @@ public class SyncWorkerTests : ClusterTestBase
             await Task.Delay(100);
             status = await grain.GetWorkStatus();
         }
-        
+
         var result = await grain.GetResult();
 
         result!.EndingValue.Should().BeGreaterThan(1);
         result!.EndingValue.Should().BeLessThan(1_000);
     }
-    
+
     [Fact]
     public async Task WhenGrainHasCancellationSupport_CanThrow()
     {


### PR DESCRIPTION
# Description

_**This is a breaking change to the package,**_ as now implementations of grains need to have the additional parameter of `GrainCancellationToken` added.

Previous signature that needed implementing:

```cs
protected abstract Task<TResult> PerformWork(TRequest request);
```

New signature:

```cs
protected abstract Task<TResult> PerformWork(
  TRequest request, GrainCancellationToken grainCancellationToken);
```

You will be safe to just add this parameter to all of your long running grain implementations, but now you have the option of performing cancellation logic (added a few tests to demonstrate this)

* `CancellationTokens` now provided to sync work grain execution through a `Start` overload.
* Old `Start` method is still available, and just news up a cancellation token for backwards compatibility.
* Grain implementations can decide what to do (or not) when a cancellation signal is received.
  * This could be to return an intermediate (but perhaps incomplete?) result, or throw.


Fixes #50

## Type of Change

Use an `x` in between the `[ ]` for each line applicable to the type of change for this PR

* [ ] Bug fix
* [x] New Feature
* [x] Documentation
* [x] Code improvement
* [x] Breaking change - if a public API changes, or any change that ***DOES*** or ***MAY*** require a major revision to the NuGet package version due to [semver](https://semver.org/).
* [x] Unit tests
* [x] Code samples
* [ ] Added your repository URL to the readme because you make use of this super cool package! ;)
* [ ] Other

## Describe testing that was performed for your change

New unit tests against cancellation token support
* Can return a value as handling for cancellation
* Can throw as handling for cancellation

## Checklist

* [x] Read the https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/CONTRIBUTING.md
* [x] Ran unit tests and ensured they passed
* [x] Added unit tests where applicable
* [x] Referenced an issue where applicable
* [x] Ran `dotnet-format` locally
