### PR TITLE
Removes the `IGrainWithGuidKey` constraint from `ISyncWorker`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build and test](https://github.com/OrleansContrib/Orleans.SyncWork/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/OrleansContrib/Orleans.SyncWork/actions/workflows/ci.yml) [![Coverage Status](https://coveralls.io/repos/github/OrleansContrib/Orleans.SyncWork/badge.svg?branch=main)](https://coveralls.io/github/OrleansContrib/Orleans.SyncWork?branch=main)
 
-![Latest NuGet Version](https://img.shields.io/nuget/v/Orleans.SyncWork) 
+![Latest NuGet Version](https://img.shields.io/nuget/v/Orleans.SyncWork)
 ![License](https://img.shields.io/github/license/OrleansContrib/Orleans.SyncWork)
 
 This package's intention is to expose an abstract base class to allow [Orleans](https://github.com/dotnet/orleans/) to work with long running, CPU bound, synchronous work, without becoming overloaded.
@@ -13,61 +13,67 @@ The project was built primarily with .net3 in mind, though the varying major ver
 
 ### Requirements
 
-* [.net 6.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
-* [.net 7.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
-* [.net 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
-* [dotnet-format](https://github.com/dotnet/format)
+- [.net 6.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+- [.net 7.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
+- [.net 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+- [dotnet-format](https://github.com/dotnet/format)
 
 ## Project Overview
 
 There are several projects within this repository, all with the idea of demonstrating and/or testing the claim that the NuGet package https://www.nuget.org/packages/Orleans.SyncWork/ does what it is claimed it does.
 
+Note that this project's major revision is kept in-line with the Orleans major version, so the project
+does not necessarily abide by [SemVer](https://semver.org/), but we try as much as possible to do so. If breaking changes are introduced, descriptions of the breaking change and how to implement against it should be provided in release notes.
+
 The projects in this repository include:
 
-* [Orleans.SyncWork](#orleanssyncwork)
-* [Orleans.SyncWork.Tests](#orleanssyncworktests)
-* [Orleans.SyncWork.Demo.Api](#orleanssyncworkdemoapi)
-* [Orleans.SyncWork.Demo.Api.Benchmark](#orleanssyncworkdemoapibenchmark)
-* [Orleans.SyncWork.Demo.Services](#orleanssyncworkdemoservices)
+- [Orleans.SyncWork](#orleanssyncwork)
+- [Orleans.SyncWork.Tests](#orleanssyncworktests)
+- [Orleans.SyncWork.Demo.Api](#orleanssyncworkdemoapi)
+- [Orleans.SyncWork.Demo.Api.Benchmark](#orleanssyncworkdemoapibenchmark)
+- [Orleans.SyncWork.Demo.Services](#orleanssyncworkdemoservices)
 
 ### Orleans.SyncWork
 
-The meat and potatoes of the project.  This project contains the abstraction of "Long Running, CPU bound, Synchronous work" in the form of an abstract base class [SyncWorker](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/SyncWorker.cs); which implements an interface [ISyncWorker](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/ISyncWorker.cs).
+The meat and potatoes of the project. This project contains the abstraction of "Long Running, CPU bound, Synchronous work" in the form of an abstract base class [SyncWorker](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/SyncWorker.cs); which implements an interface [ISyncWorker](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/ISyncWorker.cs).
 
-When long running work is identified, you can extend the base class `SyncWorker`, providing a `TRequest` and `TResponse` unique to the long running work.  This allows you to create as many `ISyncWork<TRequest, TResponse>` implementations as necessary, for all your long running CPU bound needs! (At least that is the hope.)
+When long running work is identified, you can extend the base class `SyncWorker`, providing a `TRequest` and `TResponse` unique to the long running work. This allows you to create as many `ISyncWork<TRequest, TResponse>` implementations as necessary, for all your long running CPU bound needs! (At least that is the hope.)
 
 Basic "flow" of the SyncWork:
 
-* `Start`
-* Poll `GetStatus` until a `Completed` or `Faulted` status is received
-* `GetResult` or `GetException` depending on the `GetStatus`
+- `Start`
+- Poll `GetStatus` until a `Completed` or `Faulted` status is received
+- `GetResult` or `GetException` depending on the `GetStatus`
 
 This package introduces a few "requirements" against Orleans:
 
-* In order to not overload Orleans, a `LimitedConcurrencyLevelTaskScheduler` is introduced. This task scheduler is registered (either manually or through the provided extension method) with a maximum level of concurrency for the silo being set up.  This maximum concurrency ***MUST*** allow for idle threads, lest the Orleans server be overloaded.  In testing, the general rule of thumb was `Environment.ProcessorCount - 2` max concurrency.  The important part is that the CPU is not fully "tapped out" such that the normal Orleans asynchronous messaging can't make it through due to the blocking sync work - this will make things start timing out.
-* Blocking grains are stateful, and are currently keyed on a Guid.  If in a situation where multiple grains of long running work is needed, each grain should be initialized with its own unique identity.
-* Blocking grains *likely* ***CAN NOT*** dispatch further blocking grains.  This is not yet tested under the repository, but it stands to reason that with a limited concurrency scheduler, the following scenario would lead to a deadlock:
-    * Grain A is long running
-    * Grain B is long running
-    * Grain A initializes and fires off Grain B
-    * Grain A cannot complete its work until it gets the results of Grain B
+- In order to not overload Orleans, a `LimitedConcurrencyLevelTaskScheduler` is introduced. This task scheduler is registered (either manually or through the provided extension method) with a maximum level of concurrency for the silo being set up. This maximum concurrency **_MUST_** allow for idle threads, lest the Orleans server be overloaded. In testing, the general rule of thumb was `Environment.ProcessorCount - 2` max concurrency. The important part is that the CPU is not fully "tapped out" such that the normal Orleans asynchronous messaging can't make it through due to the blocking sync work - this will make things start timing out.
+- Blocking grains are stateful, and are currently keyed on a Guid. If in a situation where multiple grains of long running work is needed, each grain should be initialized with its own unique identity.
+- Blocking grains _likely_ **_CAN NOT_** dispatch further blocking grains. This is not yet tested under the repository, but it stands to reason that with a limited concurrency scheduler, the following scenario would lead to a deadlock:
 
-    In the above scenario, if "Grain A" is "actively being worked" and it fires off a "Grain B", but "Grain A" cannot complete its work until "Grain B" finishes its own, but "Grain B" cannot *start* its work until "Grain A" finishes its work due to limited concurrency, you've run into a situation where the limited concurrency task scheduler can never finish the work of "Grain A".
-    
-    That was quite a sentence, hopefully the point was conveyed somewhat sensibly. There may be a way to avoid the above scenario, but I have not yet deeply explored it.
+  - Grain A is long running
+  - Grain B is long running
+  - Grain A initializes and fires off Grain B
+  - Grain A cannot complete its work until it gets the results of Grain B
+
+  In the above scenario, if "Grain A" is "actively being worked" and it fires off a "Grain B", but "Grain A" cannot complete its work until "Grain B" finishes its own, but "Grain B" cannot _start_ its work until "Grain A" finishes its work due to limited concurrency, you've run into a situation where the limited concurrency task scheduler can never finish the work of "Grain A".
+
+  That was quite a sentence, hopefully the point was conveyed somewhat sensibly. There may be a way to avoid the above scenario, but I have not yet deeply explored it.
 
 #### Usage
 
-Extend the base class to implement a long running grain.
+Create an interface for the grain, which implements `ISyncWorker<TRequest, TResult>`, as well as one of the `IGrainWith...Key` interfaces. Then create a new class that extends the `SyncWorker<TRequest, TResult>` abstract class, and implements the new interface that was introduced:
 
 ```cs
-public class PasswordVerifier : SyncWorker<PasswordVerifierRequest, PasswordVerifierResult>, IGrain
+public interface IPasswordVerifierGrain : ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>, IGrainWithGuidKey
+
+public class PasswordVerifierGrain : SyncWorker<PasswordVerifierRequest, PasswordVerifierResult>, IPasswordVerifierGrain
 {
     private readonly IPasswordVerifier _passwordVerifier;
 
     public PasswordVerifier(
-        ILogger<PasswordVerifier> logger, 
-        LimitedConcurrencyLevelTaskScheduler limitedConcurrencyLevelTaskScheduler, 
+        ILogger<PasswordVerifier> logger,
+        LimitedConcurrencyLevelTaskScheduler limitedConcurrencyLevelTaskScheduler,
         IPasswordVerifier passwordVerifier) : base(logger, limitedConcurrencyLevelTaskScheduler)
     {
         _passwordVerifier = passwordVerifier;
@@ -103,15 +109,15 @@ var request = new PasswordVerifierRequest()
     Password = "my super neat password that's totally secure because it's super long",
     PasswordHash = "$2a$11$vBzJ4Ewx28C127AG5x3kT.QCCS8ai0l4JLX3VOX3MzHRkF4/A5twy"
 }
-var passwordVerifyGrain = grainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+var passwordVerifyGrain = grainFactory.GetGrain<IPasswordVerifierGrain>(Guid.NewGuid());
 var result = await passwordVerifyGrain.StartWorkAndPollUntilResult(request);
 ```
 
-The above `StartWorkAndPollUntilResult` is an extension method defined in the package ([SyncWorkerExtensions](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/SyncWorkerExtensions.cs)) that `Start`s, `Poll`s, and finally `GetResult` or `GetException` upon completed work.  There would seemingly be place for improvement here as it relates to testing unexpected scenarios, configuration based polling, etc.
+The above `StartWorkAndPollUntilResult` is an extension method defined in the package ([SyncWorkerExtensions](https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/src/Orleans.SyncWork/SyncWorkerExtensions.cs)) that `Start`s, `Poll`s, and finally `GetResult` or `GetException` upon completed work. There would seemingly be place for improvement here as it relates to testing unexpected scenarios, configuration based polling, etc.
 
 ### Orleans.SyncWork.Tests
 
-Unit testing project for the work in [Orleans.SyncWork](#orleanssyncwork).  These tests bring up a "TestCluster" which is used for the full duration of the tests against the grains.
+Unit testing project for the work in [Orleans.SyncWork](#orleanssyncwork). These tests bring up a "TestCluster" which is used for the full duration of the tests against the grains.
 
 One of the tests in particular throws 10k grains onto the cluster at once, all of which are long running (~200ms each) on my machine - more than enough time to overload the cluster if the limited concurrency task scheduler is not working along side the `SyncWork` base class correctly.
 
@@ -119,9 +125,9 @@ TODO: still could use a few more unit tests here to if nothing else, document be
 
 ### Orleans.SyncWork.Demo.Api
 
-This is a demo of the `ISyncWork<TRequest, TResult>` in action.  This project is being used as both a Orleans Silo, and client.  Generally you would stand up nodes to the cluster separate from the clients against the cluster.  Since we have only one node for testing purposes, this project acts as both the silo host and client.
+This is a demo of the `ISyncWork<TRequest, TResult>` in action. This project is being used as both a Orleans Silo, and client. Generally you would stand up nodes to the cluster separate from the clients against the cluster. Since we have only one node for testing purposes, this project acts as both the silo host and client.
 
-The [OrleansDashboard](https://github.com/OrleansContrib/OrleansDashboard) is also brought up with the API.  You can see an example of hitting an endpoint in which 10k password verification requests are received here:
+The [OrleansDashboard](https://github.com/OrleansContrib/OrleansDashboard) is also brought up with the API. You can see an example of hitting an endpoint in which 10k password verification requests are received here:
 
 ![Dashboard showing 10k CPU bound, long running requests](/docs/images/dashboard.PNG)
 
@@ -186,7 +192,7 @@ public class Benchy
         var tasks = new List<Task>();
         for (var i = 0; i < TotalNumberPerBenchmark; i++)
         {
-            var grain = grainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+            var grain = grainFactory.GetGrain<IPasswordVerifierGrain>(Guid.NewGuid());
             tasks.Add(grain.StartWorkAndPollUntilResult(_request));
         }
 
@@ -197,14 +203,14 @@ public class Benchy
 
 And here are the results:
 
-|                Method |     Mean |    Error |   StdDev |
-|---------------------- |---------:|---------:|---------:|
-|                Serial | 12.399 s | 0.0087 s | 0.0077 s |
-|         MultipleTasks | 12.289 s | 0.0106 s | 0.0094 s |
+| Method                |     Mean |    Error |   StdDev |
+| --------------------- | -------: | -------: | -------: |
+| Serial                | 12.399 s | 0.0087 s | 0.0077 s |
+| MultipleTasks         | 12.289 s | 0.0106 s | 0.0094 s |
 | MultipleParallelTasks |  1.749 s | 0.0347 s | 0.0413 s |
-|          OrleansTasks |  2.130 s | 0.0055 s | 0.0084 s |
+| OrleansTasks          |  2.130 s | 0.0055 s | 0.0084 s |
 
-And of course note, that in the above the Orleans tasks are *limited* to my local cluster.  In a more real situation where you have multiple nodes to the cluster, you could expect to get better timing, though you'd probably have to deal more with network latency.
+And of course note, that in the above the Orleans tasks are _limited_ to my local cluster. In a more real situation where you have multiple nodes to the cluster, you could expect to get better timing, though you'd probably have to deal more with network latency.
 
 ### Orleans.SyncWork.Demo.Services
 

--- a/samples/Orleans.SyncWork.Demo.Api.Benchmark/Benchy.cs
+++ b/samples/Orleans.SyncWork.Demo.Api.Benchmark/Benchy.cs
@@ -59,7 +59,7 @@ public class Benchy
         var tasks = new List<Task>();
         for (var i = 0; i < TotalNumberPerBenchmark; i++)
         {
-            var grain = grainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+            var grain = grainFactory.GetGrain<IPasswordVerifierGrain>(Guid.NewGuid());
             tasks.Add(grain.StartWorkAndPollUntilResult(_request));
         }
 

--- a/samples/Orleans.SyncWork.Demo.Api/Program.cs
+++ b/samples/Orleans.SyncWork.Demo.Api/Program.cs
@@ -41,7 +41,7 @@ app
     {
         try
         {
-            var passwordVerifyGrain = grainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+            var passwordVerifyGrain = grainFactory.GetGrain<IPasswordVerifierGrain>(Guid.NewGuid());
             return await passwordVerifyGrain.StartWorkAndPollUntilResult(request);
         }
         catch (Exception e)
@@ -59,7 +59,7 @@ app
 
         for (var i = 0; i < 10_000; i++)
         {
-            var passwordVerifyGrain = grainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+            var passwordVerifyGrain = grainFactory.GetGrain<IPasswordVerifierGrain>(Guid.NewGuid());
             tasks.Add(passwordVerifyGrain.StartWorkAndPollUntilResult(request));
         }
 

--- a/samples/Orleans.SyncWork.Demo.Services/Grains/IPasswordVerifierGrain.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/Grains/IPasswordVerifierGrain.cs
@@ -1,0 +1,4 @@
+﻿namespace Orleans.SyncWork.Demo.Services.Grains;
+
+public interface IPasswordVerifierGrain
+    : ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>, IGrainWithGuidKey;

--- a/samples/Orleans.SyncWork.Demo.Services/Grains/PasswordVerifierGrain.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/Grains/PasswordVerifierGrain.cs
@@ -3,12 +3,12 @@ using Microsoft.Extensions.Logging;
 
 namespace Orleans.SyncWork.Demo.Services.Grains;
 
-public class PasswordVerifier : SyncWorker<PasswordVerifierRequest, PasswordVerifierResult>
+public class PasswordVerifierGrain : SyncWorker<PasswordVerifierRequest, PasswordVerifierResult>, IPasswordVerifierGrain
 {
     private readonly IPasswordVerifier _passwordVerifier;
 
-    public PasswordVerifier(
-        ILogger<PasswordVerifier> logger,
+    public PasswordVerifierGrain(
+        ILogger<PasswordVerifierGrain> logger,
         LimitedConcurrencyLevelTaskScheduler limitedConcurrencyLevelTaskScheduler,
         IPasswordVerifier passwordVerifier) : base(logger, limitedConcurrencyLevelTaskScheduler)
     {

--- a/samples/Orleans.SyncWork.Demo.Services/TestGrains/GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/TestGrains/GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable.cs
@@ -4,25 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Orleans.SyncWork.Demo.Services.TestGrains;
 
-[GenerateSerializer]
-public class TestGrainException : Exception
-{
-    public TestGrainException(string message) : base(message) { }
-}
-
-[GenerateSerializer]
-public class TestDelayExceptionRequest
-{
-    [Id(0)]
-    public int MsDelayPriorToResult { get; set; }
-}
-
-[GenerateSerializer]
-public class TestDelayExceptionResult
-{
-}
-
-public class GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable : SyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>
+public class GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable : SyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>, IGrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable
 {
     public GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable(
         ILogger<GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable> logger,
@@ -37,3 +19,20 @@ public class GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable : Sync
         throw new TestGrainException("This is an expected exception, I'm testing for it!");
     }
 }
+
+[GenerateSerializer]
+public class TestGrainException : Exception
+{
+    public TestGrainException(string message) : base(message) { }
+}
+
+[GenerateSerializer]
+public class TestDelayExceptionRequest
+{
+    [Id(0)]
+    public int MsDelayPriorToResult { get; set; }
+}
+
+[GenerateSerializer]
+public class TestDelayExceptionResult;
+

--- a/samples/Orleans.SyncWork.Demo.Services/TestGrains/GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/TestGrains/GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable.cs
@@ -4,25 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Orleans.SyncWork.Demo.Services.TestGrains;
 
-[GenerateSerializer]
-public class TestDelaySuccessRequest
-{
-    [Id(0)]
-    public DateTime Started { get; set; }
-    [Id(1)]
-    public int MsDelayPriorToResult { get; set; }
-}
-
-[GenerateSerializer]
-public class TestDelaySuccessResult
-{
-    [Id(0)]
-    public DateTime Started { get; set; }
-    [Id(1)]
-    public DateTime Ended { get; set; }
-}
-
-public class GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable : SyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>
+public class GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable : SyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>, IGrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable
 {
     public GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable(
         ILogger<GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable> logger,
@@ -39,4 +21,22 @@ public class GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable : SyncWo
             Ended = DateTime.UtcNow
         };
     }
+}
+
+[GenerateSerializer]
+public class TestDelaySuccessRequest
+{
+    [Id(0)]
+    public DateTime Started { get; set; }
+    [Id(1)]
+    public int MsDelayPriorToResult { get; set; }
+}
+
+[GenerateSerializer]
+public class TestDelaySuccessResult
+{
+    [Id(0)]
+    public DateTime Started { get; set; }
+    [Id(1)]
+    public DateTime Ended { get; set; }
 }

--- a/samples/Orleans.SyncWork.Demo.Services/TestGrains/IGrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/TestGrains/IGrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable.cs
@@ -1,0 +1,5 @@
+﻿namespace Orleans.SyncWork.Demo.Services.TestGrains;
+
+public interface
+    IGrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable :
+    ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>, IGrainWithGuidKey;

--- a/samples/Orleans.SyncWork.Demo.Services/TestGrains/IGrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable.cs
+++ b/samples/Orleans.SyncWork.Demo.Services/TestGrains/IGrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable.cs
@@ -1,0 +1,5 @@
+﻿namespace Orleans.SyncWork.Demo.Services.TestGrains;
+
+public interface
+    IGrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable :
+    ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>, IGrainWithGuidKey;

--- a/src/Orleans.SyncWork/ISyncWorker.cs
+++ b/src/Orleans.SyncWork/ISyncWorker.cs
@@ -9,7 +9,7 @@ namespace Orleans.SyncWork;
 /// </summary>
 /// <typeparam name="TRequest">The type of request to dispatch.</typeparam>
 /// <typeparam name="TResult">The type of result to receive.</typeparam>
-public interface ISyncWorker<in TRequest, TResult> : IGrainWithGuidKey
+public interface ISyncWorker<in TRequest, TResult> : IGrain
 {
     /// <summary>
     /// Start long running work with the provided parameter.

--- a/test/Orleans.SyncWork.Tests/SyncWorkerExtensionMethodTests.cs
+++ b/test/Orleans.SyncWork.Tests/SyncWorkerExtensionMethodTests.cs
@@ -22,7 +22,7 @@ public class SyncWorkerExtensionMethodTests : ClusterTestBase
     [Fact]
     public async Task WhenGivenValidPasswordAndHash_ShouldVerify()
     {
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IPasswordVerifierGrain>(Guid.NewGuid());
 
         var request = new PasswordVerifierRequest
         {
@@ -38,7 +38,7 @@ public class SyncWorkerExtensionMethodTests : ClusterTestBase
     [Fact]
     public async Task WhenGivenInvalidPasswordAndHash_ShouldNotVerify()
     {
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IPasswordVerifierGrain>(Guid.NewGuid());
 
         var request = new PasswordVerifierRequest
         {
@@ -54,7 +54,7 @@ public class SyncWorkerExtensionMethodTests : ClusterTestBase
     [Fact]
     public async Task WhenGivenBadHashFormat_ShouldException()
     {
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IPasswordVerifierGrain>(Guid.NewGuid());
 
         var request = new PasswordVerifierRequest
         {

--- a/test/Orleans.SyncWork.Tests/SyncWorkerTests.cs
+++ b/test/Orleans.SyncWork.Tests/SyncWorkerTests.cs
@@ -35,7 +35,7 @@ public class SyncWorkerTests : ClusterTestBase
         };
         for (var i = 0; i < totalInvokes; i++)
         {
-            var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+            var grain = Cluster.GrainFactory.GetGrain<IPasswordVerifierGrain>(Guid.NewGuid());
             tasks.Add(grain.StartWorkAndPollUntilResult(request));
         }
 
@@ -62,7 +62,7 @@ public class SyncWorkerTests : ClusterTestBase
         };
         for (var i = 0; i < 10_000; i++)
         {
-            var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+            var grain = Cluster.GrainFactory.GetGrain<IPasswordVerifierGrain>(Guid.NewGuid());
             tasks.Add(grain.StartWorkAndPollUntilResult(request));
         }
 
@@ -82,7 +82,7 @@ public class SyncWorkerTests : ClusterTestBase
     [Fact]
     public async Task WhenGrainNotStarted_ShouldThrowOnAttemptingToRetrieveStatus()
     {
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IGrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable>(Guid.NewGuid());
 
         var action = new Func<Task>(async () => await grain.GetWorkStatus());
 
@@ -93,7 +93,7 @@ public class SyncWorkerTests : ClusterTestBase
     public async Task WhenGrainStartedButWorkNotCompleted_ShouldReturnStatusRunningOnGetStatus()
     {
         var delay = 2500;
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IGrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable>(Guid.NewGuid());
         await grain.Start(new TestDelaySuccessRequest()
         {
             Started = DateTime.UtcNow,
@@ -115,7 +115,7 @@ public class SyncWorkerTests : ClusterTestBase
     public async Task WhenGrainStartedButWorkNotCompleted_ShouldThrowWhenAttemptingToRetrieveResults()
     {
         var delay = 5000;
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IGrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable>(Guid.NewGuid());
         await grain.Start(new TestDelaySuccessRequest()
         {
             Started = DateTime.UtcNow,
@@ -131,7 +131,7 @@ public class SyncWorkerTests : ClusterTestBase
     public async Task WhenGrainExceptionStartedButWorkNotCompleted_ShouldReturnStatusRunningOnGetStatus()
     {
         var delay = 2500;
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IGrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable>(Guid.NewGuid());
         await grain.Start(new TestDelayExceptionRequest()
         {
             MsDelayPriorToResult = delay
@@ -152,7 +152,7 @@ public class SyncWorkerTests : ClusterTestBase
     public async Task WhenExceptionGrainStartedButWorkNotCompleted_ShouldThrowWhenAttemptingToRetrieveResults()
     {
         var delay = 5000;
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IGrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable>(Guid.NewGuid());
         await grain.Start(new TestDelayExceptionRequest()
         {
             MsDelayPriorToResult = delay
@@ -174,7 +174,7 @@ public class SyncWorkerTests : ClusterTestBase
             MsDelayPriorToResult = 10
         };
 
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IGrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable>(Guid.NewGuid());
         var result = await grain.StartWorkAndPollUntilResult(request);
 
         result.Started.Should().Be(started);
@@ -191,7 +191,7 @@ public class SyncWorkerTests : ClusterTestBase
             MsDelayPriorToResult = 10
         };
 
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IGrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable>(Guid.NewGuid());
         await grain.Start(request);
 
         var status = await grain.GetWorkStatus();
@@ -214,7 +214,7 @@ public class SyncWorkerTests : ClusterTestBase
             MsDelayPriorToResult = 10
         };
 
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IGrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable>(Guid.NewGuid());
         var action = new Func<Task>(async () => await grain.StartWorkAndPollUntilResult(request));
 
         await action.Should().ThrowAsync<TestGrainException>();
@@ -228,7 +228,7 @@ public class SyncWorkerTests : ClusterTestBase
             MsDelayPriorToResult = 10
         };
 
-        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<IGrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable>(Guid.NewGuid());
         await grain.Start(request);
 
         var status = await grain.GetWorkStatus();


### PR DESCRIPTION
# Description

**_This is a breaking change to the package_**, but does allow for more control over the implementations of long running grains.

Removes the `IGrainWithGuidKey` constraint from `ISyncWorker`.

`ISyncWorker` was defined as:

```cs
public ISyncWorker<in TRequest, TResult> : IGrainWithGuidKey
```

Now it is defined as:

```cs
public ISyncWorker<in TRequest, TResult> : IGrain
```

This will allow implementations against the base class `SyncWorker<TRequest, TResult>` to specify the key type that fits their needs.

Previously, a "grain interface" was not ***required*** for implementations, now it will certainly make things easier to grok, albeit with an additional interface per long running grain.

Old implementation:

```cs
public class PasswordVerifier : SyncWorker<PasswordVerifierRequest, PasswordVerifierResult>
{
  // ...
}
```

New implementation:

```cs
// now specifying the key type in the grain interface
public interface IPasswordVerifierGrain : ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>, IGrainWithGuidKey

public class PasswordVerifierGrain : SyncWorker<PasswordVerifierRequest, PasswordVerifierResult>, IPasswordVerifierGrain
{
  // ...
}
```

Old calling code:

```cs
var grain = grainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
```

New calling code:

```cs
var grain = grainFactory.GetGrain<IPasswordVerifierGrain>(Guid.NewGuid());
```

Fixes #52

## Type of Change

Use an `x` in between the `[ ]` for each line applicable to the type of change for this PR

* [ ] Bug fix
* [x] New Feature
* [x] Documentation
* [x] Code improvement
* [x] Breaking change - if a public API changes, or any change that ***DOES*** or ***MAY*** require a major revision to the NuGet package version due to [semver](https://semver.org/).
* [x] Unit tests
* [x] Code samples
* [ ] Added your repository URL to the readme because you make use of this super cool package! ;)
* [ ] Other

## Describe testing that was performed for your change

Updated existing tests

## Checklist

* [x] Read the https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/CONTRIBUTING.md
* [x] Ran unit tests and ensured they passed
* [x] Added unit tests where applicable
* [x] Referenced an issue where applicable
* [x] Ran `dotnet-format` locally
