### PR TITLE
Allow returning NotStarted from GetWorkStatus

### DIFF
--- a/src/Orleans.SyncWork/SyncWorker.cs
+++ b/src/Orleans.SyncWork/SyncWorker.cs
@@ -56,17 +56,7 @@ public abstract class SyncWorker<TRequest, TResult> : Grain, ISyncWorker<TReques
     }
 
     /// <inheritdoc />
-    public Task<SyncWorkStatus> GetWorkStatus()
-    {
-        if (_status == SyncWorkStatus.NotStarted)
-        {
-            Logger.LogError("{Method} was in a status of {WorkStatus}", nameof(GetWorkStatus), SyncWorkStatus.NotStarted);
-            DeactivateOnIdle();
-            throw new InvalidStateException(_status);
-        }
-
-        return Task.FromResult(_status);
-    }
+    public Task<SyncWorkStatus> GetWorkStatus() => Task.FromResult(_status);
 
     /// <inheritdoc />
     public Task<Exception?> GetException()

--- a/test/Orleans.SyncWork.Tests/SyncWorkerTests.cs
+++ b/test/Orleans.SyncWork.Tests/SyncWorkerTests.cs
@@ -71,22 +71,13 @@ public class SyncWorkerTests : ClusterTestBase
         tasks.Select(task => task.Result).Should().OnlyContain(result => true);
     }
 
-    /// <summary>
-    /// This is to protect against cases where the silo restarts and the instance state is lost.
-    /// The class' intention is to always start work with a request, request the status, retrieve the result.
-    ///
-    /// If the silo restarts, the "worked" task is lost, and status reset to "NotStarted", throwing in that scenario
-    /// allows for a faster turnaround on the side of consumers in order to handle the silo restart - probably by
-    /// redispatching the work.
-    /// </summary>
     [Fact]
-    public async Task WhenGrainNotStarted_ShouldThrowOnAttemptingToRetrieveStatus()
+    public async Task WhenGrainNotStarted_ShouldReturnStatusNotStartedOnGetStatus()
     {
         var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
 
-        var action = new Func<Task>(async () => await grain.GetWorkStatus());
-
-        await action.Should().ThrowAsync<InvalidStateException>();
+        var status = await grain.GetWorkStatus();
+        status.Should().Be(Enums.SyncWorkStatus.NotStarted);
     }
 
     [Fact]


### PR DESCRIPTION
# Description

Please include a summary of problem/issue this pull request solves/accomplishes.

Fixes # (issue number)

## Type of Change

Use an `x` in between the `[ ]` for each line applicable to the type of change for this PR

* [ ] Bug fix
* [ ] New Feature
* [ ] Documentation
* [x] Code improvement
* [x] Breaking change - if a public API changes, or any change that ***DOES*** or ***MAY*** require a major revision to the NuGet package version due to [semver](https://semver.org/).
* [x] Unit tests
* [ ] Code samples
* [ ] Added your repository URL to the readme because you make use of this super cool package! ;)
* [ ] Other

Please describe if other

## Describe testing that was performed for your change

Remove section if not applicable

## Checklist

* [x] Read the https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/CONTRIBUTING.md
* [x] Ran unit tests and ensured they passed
* [x] Added unit tests where applicable
* [x] Referenced an issue where applicable
* [x] Ran `dotnet-format` locally
