### PR TITLE
Trying to bring back the multi target build/test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
   check-code-formatting:
     runs-on: ubuntu-latest
-    name: Check code formating against editorconfig
+    name: Check code formating against editorconfig 🔎
 
     steps:
     - name: Checkout code
@@ -32,8 +32,12 @@ jobs:
 
   build-and-test:
 
+    needs: check-code-formatting
     runs-on: ubuntu-latest
-    name: dotnet build and test
+     strategy:
+      matrix:
+        target-framework: [ 'net8.0', 'net9.0' ]
+    name: dotnet build and test targeting ${{ matrix.target-framework }} 🧪
 
     steps:
     - name: Checkout code
@@ -44,7 +48,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: |
+          8.0.x
+          9.0.x
     
     - name: Restore dependencies
       run: dotnet restore
@@ -53,4 +59,4 @@ jobs:
       run: dotnet build -c Release --no-restore
     
     - name: Test
-      run: dotnet test test/Orleans.SyncWork.Tests/Orleans.SyncWork.Tests.csproj -c Release --no-build --verbosity normal --filter "Category!=LongRunning"
+      run: dotnet test test/Orleans.SyncWork.Tests/Orleans.SyncWork.Tests.csproj -f ${{ matrix.target-framework }} -c Release --no-build --verbosity normal --filter "Category!=LongRunning"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     needs: check-code-formatting
     runs-on: ubuntu-latest
-     strategy:
+    strategy:
       matrix:
         target-framework: [ 'net8.0', 'net9.0' ]
     name: dotnet build and test targeting ${{ matrix.target-framework }} 🧪

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,7 +10,7 @@ jobs:
 
   check-code-formatting:
     runs-on: ubuntu-latest
-    name: Check code formating against editorconfig
+    name: Check code formating against editorconfig 🔎
 
     steps:
     - name: Checkout code
@@ -29,10 +29,14 @@ jobs:
     - name: Check Code Format
       run: dotnet-format --check
 
-  build-test-and-deploy:
+  build-test:
 
     needs: check-code-formatting
     runs-on: ubuntu-latest
+     strategy:
+      matrix:
+        target-framework: [ 'net8.0', 'net9.0' ]
+    name: dotnet build and test targeting ${{ matrix.target-framework }} 🧪
 
     steps:
     - name: Checkout code
@@ -43,7 +47,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 9.0.x
+         dotnet-version: |
+          8.0.x
+          9.0.x
     
     - name: Restore dependencies
       run: dotnet restore
@@ -52,10 +58,32 @@ jobs:
       run: dotnet build -c Release --no-restore
     
     - name: Test
-      run: dotnet test -c Release --no-restore --no-build --verbosity normal --filter "Category!=LongRunning"
+      run: dotnet test -f ${{ matrix.target-framework }} -c Release --no-restore --no-build --verbosity normal --filter "Category!=LongRunning"
 
     - name: Pack
       run: dotnet pack src/Orleans.SyncWork/Orleans.SyncWork.csproj -c Release --no-restore --no-build --include-symbols -p:SymbolPackageFormat=snupkg -o .
+
+    - name: Push to NuGet
+      run: dotnet nuget push *.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_KEY}}
+
+  deploy:
+    needs: build-test
+    runs-on: ubuntu-latest
+    name: Deploy to nuget 🚀
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+         dotnet-version: 8.0.x
+    
+    - name: Pack
+      run: dotnet pack src/Orleans.SyncWork/Orleans.SyncWork.csproj -f net8.0 -c Release --no-restore --no-build --include-symbols -p:SymbolPackageFormat=snupkg -o .
 
     - name: Push to NuGet
       run: dotnet nuget push *.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_KEY}}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,7 +33,7 @@ jobs:
 
     needs: check-code-formatting
     runs-on: ubuntu-latest
-     strategy:
+    strategy:
       matrix:
         target-framework: [ 'net8.0', 'net9.0' ]
     name: dotnet build and test targeting ${{ matrix.target-framework }} 🧪

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <!-- 


### PR DESCRIPTION
# Description

Build/test for both `.net8` and `.net9` within pipeline, publish as `net8.0` package

Fixes #65 

## Type of Change

Use an `x` in between the `[ ]` for each line applicable to the type of change for this PR

* [ ] Bug fix
* [x] New Feature
* [ ] Documentation
* [x] Code improvement
* [ ] Breaking change - if a public API changes, or any change that ***DOES*** or ***MAY*** require a major revision to the NuGet package version due to [semver](https://semver.org/).
* [ ] Unit tests
* [ ] Code samples
* [ ] Added your repository URL to the readme because you make use of this super cool package! ;)
* [ ] Other

Please describe if other

## Describe testing that was performed for your change

Added CICD steps to target both `.net8` and `.net9`, with the intention that the package can be published with `.net8`, but still used with `.net9`?  that's my hope anyway 😅 

## Checklist

* [x] Read the https://github.com/OrleansContrib/Orleans.SyncWork/blob/main/CONTRIBUTING.md
* [x] Ran unit tests and ensured they passed
* [ ] Added unit tests where applicable
* [ ] Referenced an issue where applicable
* [x] Ran `dotnet-format` locally
